### PR TITLE
Bug fix to undefined variable name

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -29,7 +29,7 @@ export default {
     }
     addEventListener("hashchange", handleHashChange)
     return function() {
-      removeEventListener("hashchange", handleLocationChange)
+      removeEventListener("hashchange", handleHashChange)
     }
   }
 }


### PR DESCRIPTION
There's a bug in the unsubscribe function returned by your `location.subscribe` method. This PR should fix it.